### PR TITLE
Apolo: Ajustando deletes com cache nas interrações e cor layout padrão - VLT-143 - VLT-144

### DIFF
--- a/components/molecules/Sidebar/ZSidebar.vue
+++ b/components/molecules/Sidebar/ZSidebar.vue
@@ -1,13 +1,5 @@
 <template>
-  <div
-    style="
-      height: 100%;
-      position: fixed;
-      width: 100%;
-      margin-top: 5.2rem;
-      z-index: 999;
-    "
-  >
+  <div style="height: 100%; position: fixed; width: 100%; margin-top: 5.2rem">
     <va-sidebar :hoverable="toggle" color="background-primary">
       <ZSidebarItem
         v-for="item in titles"

--- a/components/organisms/Datatables/Players/ZDatatablesPlayers.vue
+++ b/components/organisms/Datatables/Players/ZDatatablesPlayers.vue
@@ -182,6 +182,8 @@ export default defineComponent({
         confirmSuccess("Usuário(s) deletado(s) com sucesso!", () => {
           this.items = this.items.filter((item) => !ids.includes(item.id));
         });
+
+        this.getPlayers({ fetchPolicy: "network-only" });
       } catch (error) {
         console.error(error);
         this.error = true;
@@ -235,7 +237,7 @@ export default defineComponent({
       };
     },
 
-    getPlayers() {
+    getPlayers(fetchPolicyOptions = {}) {
       this.loading = true;
       this.items = [];
 
@@ -262,7 +264,9 @@ export default defineComponent({
 
       const {
         result: { value },
-      } = useQuery(query, consult);
+      } = useQuery(query, consult, {
+        fetchPolicy: fetchPolicyOptions.fetchPolicy || "cache-first", // Usa 'network-only' quando quer buscar nova consulta, senão 'cache-first'
+      });
 
       const { onResult } = useQuery(query, consult);
 

--- a/components/organisms/Datatables/Teams/ZDatatablesTeams.vue
+++ b/components/organisms/Datatables/Teams/ZDatatablesTeams.vue
@@ -174,6 +174,8 @@ export default defineComponent({
         confirmSuccess("Time(s) deletado(s) com sucesso!", () => {
           this.items = this.items.filter((item) => !ids.includes(item.id));
         });
+
+        this.getTeams({ fetchPolicy: "network-only" });
       } catch (error) {
         console.error(error);
         this.error = true;
@@ -230,7 +232,7 @@ export default defineComponent({
       };
     },
 
-    getTeams() {
+    getTeams(fetchPolicyOptions = {}) {
       this.loading = true;
       this.items = [];
 
@@ -262,7 +264,9 @@ export default defineComponent({
 
       const {
         result: { value },
-      } = useQuery(query, consult);
+      } = useQuery(query, consult, {
+        fetchPolicy: fetchPolicyOptions.fetchPolicy || "cache-first", // Usa 'network-only' quando quer buscar nova consulta, senão 'cache-first'
+      });
 
       const { onResult } = useQuery(query, consult);
 

--- a/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
+++ b/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
@@ -189,6 +189,8 @@ export default defineComponent({
         confirmSuccess("Treino(s) deletado(s) com sucesso!", () => {
           this.items = this.items.filter((item) => !ids.includes(item.id));
         });
+
+        this.getTrainings({ fetchPolicy: "network-only" });
       } catch (error) {
         console.error(error);
         this.error = true;
@@ -243,7 +245,7 @@ export default defineComponent({
       };
     },
 
-    getTrainings() {
+    getTrainings(fetchPolicyOptions = {}) {
       this.loading = true;
       this.items = [];
 
@@ -277,7 +279,9 @@ export default defineComponent({
         result: { value },
       } = useQuery(query, consult);
 
-      const { onResult } = useQuery(query, consult);
+      const { onResult } = useQuery(query, consult, {
+        fetchPolicy: fetchPolicyOptions.fetchPolicy || "cache-first", // Usa 'network-only' quando quer buscar nova consulta, senão 'cache-first'
+      });
 
       onResult((result) => {
         if (result?.data?.trainings?.data.length > 0) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -27,7 +27,16 @@ export default defineNuxtConfig({
   },
   vuestic: {
     config: {
-      // Config here
+        colors: {
+            presets: {
+                light: {
+                    primary: '#FF4E1B',
+                    myCoolColor: '#ff00ff',
+                    onMyCoolColor: '#ffffff',
+                    dark: '#131B23'
+                }
+            }
+        },
     },
     css: true,
   },


### PR DESCRIPTION
### O que?

* Feito ajustes para a cor primaria, passando para o padrão Laranja.
* Ajuste nos métodos de delete, para chamar a consulta principal de listagem novamente desabilitando o cache, para buscar as informações mais atualizadas do banco de dados.

### Por quê?

* O designer de cores do sistema será refeito para os padrões de cores em tom laranja.
* Melhor interação na tela após deletar um item.

### Como?

* Ajustado cor nas configurações do vuestic.
* Adicionado parâmetro para consultas de listagem para buscar sem cache a informação.

### Capturas de tela

![image](https://github.com/Zoren-Software/VoleiClub-Front/assets/25940408/7635f407-9943-465b-a080-bf517c3f4183)

