### PR TITLE
feat(treino): adicionando filtro de data para listagem de treinos - VLT-140

### DIFF
--- a/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
+++ b/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
@@ -50,6 +50,31 @@
             />
           </div>
         </div>
+        <div class="flex flex-col md3 mb-2">
+          <div class="item mr-2">
+            <VaDateInput
+              v-model="variablesGetTrainings.filter.dateStart"
+              name="dateStart"
+              label="Inicio Data Treino"
+              id="date-training"
+              style="width: 100%"
+              class="mb-3"
+            />
+          </div>
+        </div>
+        <div class="flex flex-col md3 mb-2">
+          <div class="item mr-2">
+            <VaDateInput
+              v-model="variablesGetTrainings.filter.dateEnd"
+              name="dateEnd"
+              label="Fim Data Treino"
+              id="date-training"
+              style="width: 100%"
+              class="mb-3"
+            />
+          </div>
+        </div>
+        {{ variablesGetTrainings.filter }}
       </div>
     </template>
 
@@ -145,6 +170,8 @@ export default defineComponent({
           usersIds: [],
           playersIds: [],
           search: "%%",
+          dateStart: moment().toISOString(),
+          dateEnd: moment().toISOString(),
         },
         orderBy: "id",
         sortedBy: "desc",
@@ -240,8 +267,12 @@ export default defineComponent({
 
     clearSearch() {
       this.variablesGetTrainings.filter = {
-        search: "%%",
         teamsIds: [],
+        usersIds: [],
+        playersIds: [],
+        search: "%%",
+        dateStart: moment().format("YYYY-MM-DD"), // data de hoje
+        dateEnd: moment().format("YYYY-MM-DD"), // data de hoje
       };
     },
 
@@ -265,6 +296,18 @@ export default defineComponent({
         (player) => parseInt(player.value)
       );
 
+      let dateEnd = this.variablesGetTrainings.filter.dateEnd;
+
+      if (dateEnd) {
+        dateEnd = moment(dateEnd).format("YYYY-MM-DD 23:59:59");
+      }
+
+      let dateStart = this.variablesGetTrainings.filter.dateStart;
+
+      if (dateStart) {
+        dateStart = moment(dateStart).format("YYYY-MM-DD 00:00:00");
+      }
+
       const consult = {
         ...this.variablesGetTrainings,
         filter: {
@@ -272,6 +315,8 @@ export default defineComponent({
           teamsIds: teamsIdsValues,
           usersIds: usersIdsValues,
           playersIds: playersIdsValues,
+          dateStart,
+          dateEnd,
         },
       };
 

--- a/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
+++ b/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
@@ -74,7 +74,6 @@
             />
           </div>
         </div>
-        {{ variablesGetTrainings.filter }}
       </div>
     </template>
 
@@ -170,8 +169,8 @@ export default defineComponent({
           usersIds: [],
           playersIds: [],
           search: "%%",
-          dateStart: moment().toISOString(),
-          dateEnd: moment().toISOString(),
+          dateStart: null,
+          dateEnd: null,
         },
         orderBy: "id",
         sortedBy: "desc",
@@ -271,8 +270,8 @@ export default defineComponent({
         usersIds: [],
         playersIds: [],
         search: "%%",
-        dateStart: moment().format("YYYY-MM-DD"), // data de hoje
-        dateEnd: moment().format("YYYY-MM-DD"), // data de hoje
+        dateStart: null, // data de hoje
+        dateEnd: null, // data de hoje
       };
     },
 


### PR DESCRIPTION
### O que?

Adicionado campos de seleção de data para selecionar um range de datas para os filtros de treino.

### Por quê?

Para adicionar uma facilidade maior ao filtrar os treinos, era um filtro bem essencial.

### Capturas de tela

![image](https://github.com/Zoren-Software/VoleiClub-Front/assets/25940408/65c13cad-769b-4301-8133-a86056eb1aea)

