### PR TITLE
feat(usuário): redirecionando usuário em caso de perda de autenticação - VLT-145

### DIFF
--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -3,6 +3,7 @@ export default defineNuxtRouteMiddleware((to, from, next) => {
   const token = localStorage.getItem('apollo:default.token')
   
   if (to.path != '/login' && token == null) {
+      localStorage.removeItem('apollo:default.token') // Limpar o token
       return '/login'
   }
   


### PR DESCRIPTION
### O que?

Quando o sistema estava indisponível, ou uma desautenticação fosse feita, o usuário ficava navegando em tela com todas as listagens incorretas, e parecendo que existia um problema ao retornar os dados, e podendo fazer qualquer ação (mesmo não a conseguindo executar).

### Por quê?

O processo correto seria, ao usuário perder a autenticação ser redirecionado para a tela de login para tentar o fazer novamente.

### Como?

Nos middlewares de autenticação do usuário e redirecionamento para o login, foi necessário acrestar uma validação, que se o apollo retornar que o usuário esta "Unauthenticated" ele será redirecionado para a tela de login.

