### PR TITLE
feat(treino): adicionando métricas na visualização de confirmação de treinos - VLT-150

### DIFF
--- a/components/molecules/Cards/ZCardViewMetricsPresenceIntention.vue
+++ b/components/molecules/Cards/ZCardViewMetricsPresenceIntention.vue
@@ -1,0 +1,100 @@
+<template>
+  <ZCard
+    :stripe="stripe"
+    :stripeColor="stripeColor"
+    :title="title"
+    :color="color"
+  >
+    <div class="row">
+      <div class="flex flex-col md9">
+        <div class="item">
+          <h2 class="mt-2">Confirmados: {{ data.confirmed }}</h2>
+          <h2>Pendentes: {{ data.pending }}</h2>
+          <h2>Rejeitados: {{ data.rejected }}</h2>
+        </div>
+      </div>
+      <div class="flex flex-col md3">
+        <div class="item">
+          <h2 class="mt-2">{{ data.confirmedPercentage }}%</h2>
+          <h2>{{ data.pendingPercentage }}%</h2>
+          <h2>{{ data.rejectedPercentage }}%</h2>
+        </div>
+      </div>
+      <div class="flex flex-col md12 mt-3">
+        <div class="item">
+          <h2>
+            Total Pessoas no Time:
+            {{ data.confirmed + data.pending + data.rejected }}
+          </h2>
+        </div>
+      </div>
+    </div>
+  </ZCard>
+</template>
+
+<script>
+import ZCard from "~/components/atoms/Cards/ZCard";
+
+export default {
+  components: {
+    ZCard,
+  },
+  emits: ["click"],
+  props: {
+    stripe: {
+      type: Boolean,
+      default: false,
+    },
+    stripeColor: {
+      type: String,
+      default: "primary",
+    },
+    title: {
+      type: String,
+      default: "Título",
+    },
+    color: {
+      type: String,
+      default: "primary",
+    },
+    textButton: {
+      type: String,
+      default: "Adicionar",
+    },
+    icon: {
+      type: String,
+      default: "plus",
+    },
+    step: {
+      type: Number,
+      default: 0,
+    },
+    stepDisabled: {
+      type: Number,
+      default: 0,
+    },
+    total: {
+      type: Number,
+      default: 0,
+    },
+    textTotal: {
+      type: String,
+      default: "Registros",
+    },
+    isSlotEmpty: {
+      type: Boolean,
+      default: false,
+    },
+    data: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+};
+</script>
+
+<style scoped>
+.border-custom {
+  border-left: 2px solid var(--va-primary);
+}
+</style>

--- a/components/molecules/Cards/ZCardViewMetricsPresenceIntention.vue
+++ b/components/molecules/Cards/ZCardViewMetricsPresenceIntention.vue
@@ -24,7 +24,7 @@
         <div class="item">
           <h2>
             Total Pessoas no Time:
-            {{ data.confirmed + data.pending + data.rejected }}
+            {{ data.total }}
           </h2>
         </div>
       </div>

--- a/components/molecules/Cards/ZCardViewMetricsPresenceIntention.vue
+++ b/components/molecules/Cards/ZCardViewMetricsPresenceIntention.vue
@@ -6,14 +6,14 @@
     :color="color"
   >
     <div class="row">
-      <div class="flex flex-col md9">
+      <div class="flex flex-col md10">
         <div class="item">
           <h2 class="mt-2">Confirmados: {{ data.confirmed }}</h2>
           <h2>Pendentes: {{ data.pending }}</h2>
           <h2>Rejeitados: {{ data.rejected }}</h2>
         </div>
       </div>
-      <div class="flex flex-col md3">
+      <div class="flex flex-col md2">
         <div class="item">
           <h2 class="mt-2">{{ data.confirmedPercentage }}%</h2>
           <h2>{{ data.pendingPercentage }}%</h2>

--- a/components/molecules/Cards/ZCardViewMetricsRealPresence.vue
+++ b/components/molecules/Cards/ZCardViewMetricsRealPresence.vue
@@ -1,0 +1,100 @@
+<template>
+  <ZCard
+    :stripe="stripe"
+    :stripeColor="stripeColor"
+    :title="title"
+    :color="color"
+  >
+    <div class="row">
+      <div class="flex flex-col md9">
+        <div class="item">
+          <h2 class="mt-2">Confirmados: {{ data.confirmed }}</h2>
+          <h2>Pendentes: {{ data.pending }}</h2>
+          <h2>Rejeitados: {{ data.rejected }}</h2>
+        </div>
+      </div>
+      <div class="flex flex-col md3">
+        <div class="item">
+          <h2 class="mt-2">{{ data.confirmedPercentage }}%</h2>
+          <h2>{{ data.pendingPercentage }}%</h2>
+          <h2>{{ data.rejectedPercentage }}%</h2>
+        </div>
+      </div>
+      <div class="flex flex-col md12 mt-3">
+        <div class="item">
+          <h2>
+            Total Pessoas no Time:
+            {{ data.confirmed + data.pending + data.rejected }}
+          </h2>
+        </div>
+      </div>
+    </div>
+  </ZCard>
+</template>
+
+<script>
+import ZCard from "~/components/atoms/Cards/ZCard";
+
+export default {
+  components: {
+    ZCard,
+  },
+  emits: ["click"],
+  props: {
+    stripe: {
+      type: Boolean,
+      default: false,
+    },
+    stripeColor: {
+      type: String,
+      default: "primary",
+    },
+    title: {
+      type: String,
+      default: "Título",
+    },
+    color: {
+      type: String,
+      default: "primary",
+    },
+    textButton: {
+      type: String,
+      default: "Adicionar",
+    },
+    icon: {
+      type: String,
+      default: "plus",
+    },
+    step: {
+      type: Number,
+      default: 0,
+    },
+    stepDisabled: {
+      type: Number,
+      default: 0,
+    },
+    total: {
+      type: Number,
+      default: 0,
+    },
+    textTotal: {
+      type: String,
+      default: "Registros",
+    },
+    isSlotEmpty: {
+      type: Boolean,
+      default: false,
+    },
+    data: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+};
+</script>
+
+<style scoped>
+.border-custom {
+  border-left: 2px solid var(--va-primary);
+}
+</style>

--- a/components/molecules/Cards/ZCardViewMetricsRealPresence.vue
+++ b/components/molecules/Cards/ZCardViewMetricsRealPresence.vue
@@ -12,7 +12,7 @@
           <h2>Ausentes: {{ data.absence }}</h2>
         </div>
       </div>
-      <div class="flex flex-col md6">
+      <div class="flex flex-col md3">
         <div class="item">
           <h2>{{ data.presencePercentage }}%</h2>
           <h2>{{ data.absencePercentage }}%</h2>

--- a/components/molecules/Cards/ZCardViewMetricsRealPresence.vue
+++ b/components/molecules/Cards/ZCardViewMetricsRealPresence.vue
@@ -8,24 +8,14 @@
     <div class="row">
       <div class="flex flex-col md9">
         <div class="item">
-          <h2 class="mt-2">Confirmados: {{ data.confirmed }}</h2>
-          <h2>Pendentes: {{ data.pending }}</h2>
-          <h2>Rejeitados: {{ data.rejected }}</h2>
+          <h2>Presentes: {{ data.presence }}</h2>
+          <h2>Ausentes: {{ data.absence }}</h2>
         </div>
       </div>
-      <div class="flex flex-col md3">
+      <div class="flex flex-col md6">
         <div class="item">
-          <h2 class="mt-2">{{ data.confirmedPercentage }}%</h2>
-          <h2>{{ data.pendingPercentage }}%</h2>
-          <h2>{{ data.rejectedPercentage }}%</h2>
-        </div>
-      </div>
-      <div class="flex flex-col md12 mt-3">
-        <div class="item">
-          <h2>
-            Total Pessoas no Time:
-            {{ data.confirmed + data.pending + data.rejected }}
-          </h2>
+          <h2>{{ data.presencePercentage }}%</h2>
+          <h2>{{ data.absencePercentage }}%</h2>
         </div>
       </div>
     </div>

--- a/components/molecules/Datatable/Slots/ZTeam.vue
+++ b/components/molecules/Datatable/Slots/ZTeam.vue
@@ -3,8 +3,8 @@
     <ZButton size="small" color="primary"> {{ data[0].name }}</ZButton>
   </ZBadge>
   <ZButton v-if="data.name" size="small" color="primary">
-    {{ data.name }}</ZButton
-  >
+    {{ data.name }}
+  </ZButton>
 </template>
 
 <script>

--- a/components/molecules/Datatable/Slots/ZTraining.vue
+++ b/components/molecules/Datatable/Slots/ZTraining.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <div class="mb-2">
+      {{ data.name }}
+    </div>
+    <div v-if="isBeforeTrainingDate()">
+      <div class="mb-1">
+        <span class="va-text-secondary"> Confirmações de Treino </span>
+      </div>
+      <VaProgressBar
+        size="large"
+        :model-value="metricsConfirmationTraining"
+        show-percent
+        content-inside
+      />
+    </div>
+    <div v-else>
+      <div class="mb-1">
+        <span class="va-text-secondary"> Presença no Treino </span>
+      </div>
+      <VaProgressBar
+        size="large"
+        :model-value="metricsConfirmationPresence"
+        show-percent
+        content-inside
+        color="success"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import ZBadge from "~/components/atoms/Badges/ZBadge";
+import ZButton from "~/components/atoms/Buttons/ZButton";
+
+export default {
+  components: {
+    ZBadge,
+    ZButton,
+  },
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+    metrics: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      metricsConfirmationTraining:
+        this.metrics.confirmedPercentage + this.metrics.rejectedPercentage,
+      metricsConfirmationPresence: this.metrics.presencePercentage,
+    };
+  },
+  methods: {
+    isBeforeTrainingDate() {
+      return new Date(this.data.dateStart) > new Date();
+    },
+  },
+};
+</script>

--- a/components/molecules/List/ZListRelationGeneric.vue
+++ b/components/molecules/List/ZListRelationGeneric.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="d-flex align-items-center justify-content-between">
+  <!-- Aqui continha uma classe d-flex se algum layout quebrar deve ser reposto por parâmetros -->
+  <div class="align-items-center justify-content-between">
     <slot name="filter" />
     <ZButton
       v-if="!disableRelation"

--- a/components/molecules/ProgressBar/ZProgressBarMetricsTraining.vue
+++ b/components/molecules/ProgressBar/ZProgressBarMetricsTraining.vue
@@ -1,0 +1,60 @@
+<template>
+  <div>
+    <div class="mb-1 mt-3">
+      <span class="va-text-secondary"> Respostas de Intenção de Presença </span>
+    </div>
+    <VaProgressBar
+      size="large"
+      :model-value="metricsConfirmationTraining"
+      show-percent
+      content-inside
+    />
+  </div>
+  <div>
+    <div class="mb-1 mt-2">
+      <span class="va-text-secondary"> Presença no Treino </span>
+    </div>
+    <VaProgressBar
+      size="large"
+      :model-value="metricsConfirmationPresence"
+      show-percent
+      content-inside
+      color="success"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+    metrics: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      metricsConfirmationTraining:
+        this.metrics.confirmedPercentage + this.metrics.rejectedPercentage,
+      metricsConfirmationPresence: this.metrics.presencePercentage,
+    };
+  },
+  methods: {
+    isBeforeTrainingDate() {
+      return new Date(this.data.dateStart) > new Date();
+    },
+  },
+  computed: {
+    metricsConfirmationTraining() {
+      return this.metrics.confirmedPercentage + this.metrics.rejectedPercentage;
+    },
+    metricsConfirmationPresence() {
+      return this.metrics.presencePercentage;
+    },
+  },
+};
+</script>

--- a/components/molecules/Selects/ZSelectLanguage.vue
+++ b/components/molecules/Selects/ZSelectLanguage.vue
@@ -122,7 +122,6 @@ export default {
       }
     },
     setInitialValue() {
-      console.log(this.form);
       if (this.form && this.form.language) {
         const initialValue = this.items.find(
           (item) => item.value === this.form.language.value

--- a/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
+++ b/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
@@ -78,6 +78,14 @@
     </template>
 
     <!-- CELL -->
+    <template
+      #cell(name)="{ rowKey: { name, dateStart, confirmationTrainingMetrics } }"
+    >
+      <ZTraining
+        :data="{ name, dateStart }"
+        :metrics="confirmationTrainingMetrics"
+      />
+    </template>
     <template #cell(team)="{ rowKey: { team } }">
       <div v-if="team">
         <ZTeam :data="team" />
@@ -112,6 +120,7 @@ import ZSelectUser from "~/components/molecules/Selects/ZSelectUser";
 import ZUser from "~/components/molecules/Datatable/Slots/ZUser";
 import ZDateTraining from "~/components/molecules/Datatable/Slots/ZDateTraining";
 import ZTeam from "~/components/molecules/Datatable/Slots/ZTeam";
+import ZTraining from "~/components/molecules/Datatable/Slots/ZTraining";
 import TRAININGDELETE from "~/graphql/training/mutation/trainingDelete.graphql";
 import { confirmSuccess, confirmError } from "~/utils/sweetAlert2/swalHelper";
 
@@ -126,6 +135,7 @@ export default defineComponent({
     ZSelectPosition,
     ZSelectTeam,
     ZSelectUser,
+    ZTraining,
   },
 
   created() {

--- a/components/organisms/Forms/Training/ZTrainingForm.vue
+++ b/components/organisms/Forms/Training/ZTrainingForm.vue
@@ -144,6 +144,7 @@ import ZCardViewMetricsRealPresence from "~/components/molecules/Cards/ZCardView
 import ZCardViewMetricsPresenceIntention from "~/components/molecules/Cards/ZCardViewMetricsPresenceIntention";
 import ZSelectUser from "~/components/molecules/Selects/ZSelectUser";
 import CONFIRMTRAINING from "~/graphql/training/mutation/confirmTraining.graphql";
+import CONFIRMPRESENCE from "~/graphql/training/mutation/confirmPresence.graphql";
 
 const { formData } = useForm("myForm");
 

--- a/components/organisms/Forms/Training/ZTrainingForm.vue
+++ b/components/organisms/Forms/Training/ZTrainingForm.vue
@@ -107,8 +107,18 @@
             :items="form.confirmationsTraining"
             :trainingDate="form.dateValue"
           >
-            <template #filter>
-              <ZSelectUser class="mb-3" label="Jogadores" v-model="users" />
+            <template #head>
+              <ZCardViewMetricsPresenceIntention
+                class="mr-2"
+                title="Métricas do treino, intenção de presença"
+                :strip="false"
+                :data="form.confirmationTrainingMetrics"
+              />
+              <ZCardViewMetricsRealPresence
+                title="Métricas do treino, presença real"
+                :strip="false"
+                :data="form.confirmationTrainingMetrics"
+              />
             </template>
           </ZListRelationConfirmationTrainings>
         </template>
@@ -130,8 +140,9 @@ import ZDateTimeRangePicker from "~/components/molecules/Inputs/ZDateTimeRangePi
 import ZSelectFundamental from "~/components/molecules/Selects/ZSelectFundamental.vue";
 import ZSelectSpecificFundamental from "~/components/molecules/Selects/ZSelectSpecificFundamental.vue";
 import ZListRelationConfirmationTrainings from "~/components/organisms/List/Relations/ZListRelationConfirmationTrainings";
+import ZCardViewMetricsRealPresence from "~/components/molecules/Cards/ZCardViewMetricsRealPresence";
+import ZCardViewMetricsPresenceIntention from "~/components/molecules/Cards/ZCardViewMetricsPresenceIntention";
 import ZSelectUser from "~/components/molecules/Selects/ZSelectUser";
-import CONFIRMPRESENCE from "~/graphql/training/mutation/confirmPresence.graphql";
 import CONFIRMTRAINING from "~/graphql/training/mutation/confirmTraining.graphql";
 
 const { formData } = useForm("myForm");
@@ -189,6 +200,8 @@ export default {
     ZSelectSpecificFundamental,
     ZListRelationConfirmationTrainings,
     ZSelectUser,
+    ZCardViewMetricsPresenceIntention,
+    ZCardViewMetricsRealPresence,
   },
 
   emits: ["refresh"],

--- a/components/organisms/Forms/Training/ZTrainingForm.vue
+++ b/components/organisms/Forms/Training/ZTrainingForm.vue
@@ -372,7 +372,6 @@ export default {
       }
     },
     async actionConfirm(id, playerId, trainingId) {
-      console.log(id, playerId, trainingId);
       try {
         const query = gql`
           ${CONFIRMTRAINING}

--- a/components/organisms/Forms/Training/ZTrainingForm.vue
+++ b/components/organisms/Forms/Training/ZTrainingForm.vue
@@ -108,17 +108,37 @@
             :trainingDate="form.dateValue"
           >
             <template #head>
-              <ZCardViewMetricsPresenceIntention
-                class="mr-2"
-                title="Métricas do treino, intenção de presença"
-                :strip="false"
-                :data="form.confirmationTrainingMetrics"
-              />
-              <ZCardViewMetricsRealPresence
-                title="Métricas do treino, presença real"
-                :strip="false"
-                :data="form.confirmationTrainingMetrics"
-              />
+              <div class="row">
+                <div class="flex flex-col md6">
+                  <div class="item">
+                    <ZCardViewMetricsPresenceIntention
+                      class="mr-2"
+                      title="Métricas do treino, intenção de presença"
+                      :strip="false"
+                      :data="form.confirmationTrainingMetrics"
+                    />
+                  </div>
+                </div>
+                <div class="flex flex-col md6">
+                  <div class="item">
+                    <ZCardViewMetricsRealPresence
+                      title="Métricas do treino, presença real"
+                      :strip="false"
+                      :data="form.confirmationTrainingMetrics"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="flex flex-col md12">
+                  <div class="item">
+                    <ZProgressBarMetricsTraining
+                      :metrics="form.confirmationTrainingMetrics"
+                      :data="form"
+                    />
+                  </div>
+                </div>
+              </div>
             </template>
           </ZListRelationConfirmationTrainings>
         </template>
@@ -142,6 +162,7 @@ import ZSelectSpecificFundamental from "~/components/molecules/Selects/ZSelectSp
 import ZListRelationConfirmationTrainings from "~/components/organisms/List/Relations/ZListRelationConfirmationTrainings";
 import ZCardViewMetricsRealPresence from "~/components/molecules/Cards/ZCardViewMetricsRealPresence";
 import ZCardViewMetricsPresenceIntention from "~/components/molecules/Cards/ZCardViewMetricsPresenceIntention";
+import ZProgressBarMetricsTraining from "~/components/molecules/ProgressBar/ZProgressBarMetricsTraining";
 import ZSelectUser from "~/components/molecules/Selects/ZSelectUser";
 import CONFIRMTRAINING from "~/graphql/training/mutation/confirmTraining.graphql";
 import CONFIRMPRESENCE from "~/graphql/training/mutation/confirmPresence.graphql";
@@ -203,6 +224,7 @@ export default {
     ZSelectUser,
     ZCardViewMetricsPresenceIntention,
     ZCardViewMetricsRealPresence,
+    ZProgressBarMetricsTraining,
   },
 
   emits: ["refresh"],

--- a/components/organisms/List/Relations/ZListRelationConfirmationTrainings.vue
+++ b/components/organisms/List/Relations/ZListRelationConfirmationTrainings.vue
@@ -1,6 +1,7 @@
 <template>
   <ZListRelationGeneric @add="add" disableRelation>
     <template #filter>
+      <slot name="head" />
       <slot name="filter" />
     </template>
     <template #list>

--- a/graphql/training/query/training.graphql
+++ b/graphql/training/query/training.graphql
@@ -68,9 +68,14 @@ query training(
       confirmed
       pending
       rejected
+      total
       confirmedPercentage
       pendingPercentage
       rejectedPercentage
+      presence
+      absence
+      presencePercentage
+      absencePercentage
     }
     status
     dateStart

--- a/graphql/training/query/trainings.graphql
+++ b/graphql/training/query/trainings.graphql
@@ -32,6 +32,19 @@ query trainings(
         id
         name
       }
+      confirmationTrainingMetrics {
+        confirmed
+        pending
+        rejected
+        total
+        confirmedPercentage
+        pendingPercentage
+        rejectedPercentage
+        presence
+        absence
+        presencePercentage
+        absencePercentage
+      }
       status
       dateStart
       dateEnd


### PR DESCRIPTION
### O que?

Feito visualização dos dados de métricas de chamada de intenção de treino e controle de presença.

### Por quê?

* Ajustado na tela interna de confirmação de treino um painel superior para ver as métricas de confirmação de treino.
* Também foi adicionado esta visualização para os dados na listagem principal de treinos.

### Capturas de tela

![image](https://github.com/Zoren-Software/VoleiClub-Front/assets/25940408/27a3f82a-f3d5-4d4d-8157-016401d16158)
![image](https://github.com/Zoren-Software/VoleiClub-Front/assets/25940408/c20fdde8-cfcc-4555-a57f-2d17ff671405)


